### PR TITLE
Fix typo: chieftan → chieftain

### DIFF
--- a/src/epub/text/chapter-33.xhtml
+++ b/src/epub/text/chapter-33.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
 	<head>
-		<title>XXXIII: The Fall of a Chieftan</title>
+		<title>XXXIII: The Fall of a Chieftain</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
@@ -10,7 +10,7 @@
 			<section id="chapter-33" epub:type="chapter">
 				<hgroup>
 					<h3 epub:type="ordinal z3998:roman">XXXIII</h3>
-					<h4 epub:type="title">The Fall of a Chieftan</h4>
+					<h4 epub:type="title">The Fall of a Chieftain</h4>
 				</hgroup>
 				<p>There never was such an overturn in this world. Each of these six men was as though he had been struck. But with Silver the blow passed almost instantly. Every thought of his soul had been set full-stretch, like a racer, on that money; well, he was brought up in a single second, dead; and he kept his head, found his temper, and changed his plan before the others had had time to realize the disappointment.</p>
 				<p>“Jim,” he whispered, “take that, and stand by for trouble.”</p>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -147,7 +147,7 @@
 									<a href="text/chapter-32.xhtml"><span epub:type="z3998:roman">XXXII</span>: The Treasure-Hunt—The Voice Among the Trees</a>
 								</li>
 								<li>
-									<a href="text/chapter-33.xhtml"><span epub:type="z3998:roman">XXXIII</span>: The Fall of a Chieftan</a>
+									<a href="text/chapter-33.xhtml"><span epub:type="z3998:roman">XXXIII</span>: The Fall of a Chieftain</a>
 								</li>
 								<li>
 									<a href="text/chapter-34.xhtml"><span epub:type="z3998:roman">XXXIV</span>: And Last</a>


### PR DESCRIPTION
Gutenberg and IA both spell it chieftain.