### PR TITLE
Correction: Curse —> Cruise

### DIFF
--- a/src/epub/text/chapter-24.xhtml
+++ b/src/epub/text/chapter-24.xhtml
@@ -10,7 +10,7 @@
 			<section id="chapter-24" epub:type="chapter">
 				<hgroup>
 					<h3 epub:type="ordinal z3998:roman">XXIV</h3>
-					<h4 epub:type="title">The Curse of the Coracle</h4>
+					<h4 epub:type="title">The Cruise of the Coracle</h4>
 				</hgroup>
 				<p>It was broad day when I awoke and found myself tossing at the southwest end of Treasure Island. The sun was up, but was still hid from me behind the great bulk of the Spyglass, which on this side descended almost to the sea in formidable cliffs.</p>
 				<p>Haulbowline Head and Mizzenmast Hill were at my elbow, the hill bare and dark, the head bound with cliffs forty or fifty feet high and fringed with great masses of fallen rock. I was scarce a quarter of a mile to seaward, and it was my first thought to paddle in and land.</p>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -115,7 +115,7 @@
 									<a href="text/chapter-23.xhtml"><span epub:type="z3998:roman">XXIII</span>: The Ebb-Tide Runs</a>
 								</li>
 								<li>
-									<a href="text/chapter-24.xhtml"><span epub:type="z3998:roman">XXIV</span>: The Curse of the Coracle</a>
+									<a href="text/chapter-24.xhtml"><span epub:type="z3998:roman">XXIV</span>: The Cruise of the Coracle</a>
 								</li>
 								<li>
 									<a href="text/chapter-25.xhtml"><span epub:type="z3998:roman">XXV</span>: I Strike the Jolly Roger</a>


### PR DESCRIPTION
Both Gutenberg and the IA page scan read “Cruise.”
Could this have been carried over from another version of the text?

FYI: My knowledge of the ePub format is still fairly new, but as far as I can tell, these are the only two files that reference the chapter title.